### PR TITLE
Only perform install when dependencies or devDependencies have changed

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var crypto = require('crypto')
 var exec = require('child_process').exec
+var _pick = require("lodash.pick")
 
 // hashes a given file and returns the hex digest
 const hashFile = (filepath) => {
@@ -9,13 +10,7 @@ const hashFile = (filepath) => {
     var hashSum = crypto.createHash('md5')
     var contents = fs.readFileSync(filepath, 'utf-8')
     var packageBlob = JSON.parse(contents)
-    var interestingParts = [
-        'dependencies',
-        'devDependencies' ].reduce(function(acc, cur) {
-            return packageBlob[cur]
-                ? Object.assign(acc, packageBlob[cur])
-                : acc
-        }, {})
+    var interestingParts = _pick(packageBlob, 'dependencies', 'devDependencies')
     var interestingJson = JSON.stringify(interestingParts)
     hashSum.update(new Buffer(interestingJson))
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,14 +8,14 @@ const hashFile = (filepath) => {
 
     var hashSum = crypto.createHash('md5')
     var contents = fs.readFileSync(filepath, 'utf-8')
-    var packageBlob = JSON.parse(contents);
+    var packageBlob = JSON.parse(contents)
     var interestingParts = [
         'dependencies',
         'devDependencies' ].reduce(function(acc, cur) {
             return packageBlob[cur]
                 ? Object.assign(acc, packageBlob[cur])
-                : acc;
-        }, {});
+                : acc
+        }, {})
     var interestingJson = JSON.stringify(interestingParts)
     hashSum.update(new Buffer(interestingJson))
 
@@ -23,26 +23,26 @@ const hashFile = (filepath) => {
 }
 
 function findPackageJson() {
-    var current = process.cwd();
-    var last = current;
+    var current = process.cwd()
+    var last = current
     do {
-        var search = path.join(current, "package.json");
+        var search = path.join(current, "package.json")
         if (fs.existsSync(search)) {
-            return search;
+            return search
         }
-        last = current;
-        current = path.dirname(current);
+        last = current
+        current = path.dirname(current)
     } while (current !== last)
 }
 
 // returns whether or not npm install should be executed
 const watchFile = function () {
 
-    let packagePath = findPackageJson(); // __dirname + '/../../../package.json'
+    let packagePath = findPackageJson()
     if (!packagePath) {
-        console.error("Can't find package.json travelling up from current working directory");
+        console.error("Can't find package.json travelling up from current working directory")
     }
-    let packageHashPath = path.join(path.dirname(packagePath), "packagehash.txt"); // __dirname + '/../../../packagehash.txt'
+    let packageHashPath = path.join(path.dirname(packagePath), "packagehash.txt")
     let recentDigest = hashFile(packagePath)
 
     // if the hash file doesn't exist or if it does and the hash
@@ -59,7 +59,7 @@ const watchFile = function () {
 
             console.log(stdout)
             console.log(stderr)
-        });
+        })
 
         return true
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,5 @@
 var fs = require('fs')
+var path = require('path')
 var crypto = require('crypto')
 var exec = require('child_process').exec
 
@@ -6,18 +7,42 @@ var exec = require('child_process').exec
 const hashFile = (filepath) => {
 
     var hashSum = crypto.createHash('md5')
-    var contents = fs.readFileSync(filepath)
-    hashSum.update(contents)
+    var contents = fs.readFileSync(filepath, 'utf-8')
+    var packageBlob = JSON.parse(contents);
+    var interestingParts = [
+        'dependencies',
+        'devDependencies' ].reduce(function(acc, cur) {
+            return packageBlob[cur]
+                ? Object.assign(acc, packageBlob[cur])
+                : acc;
+        }, {});
+    var interestingJson = JSON.stringify(interestingParts)
+    hashSum.update(new Buffer(interestingJson))
 
     return hashSum.digest('hex')
 }
 
+function findPackageJson() {
+    var current = process.cwd();
+    var last = current;
+    do {
+        var search = path.join(current, "package.json");
+        if (fs.existsSync(search)) {
+            return search;
+        }
+        last = current;
+        current = path.dirname(current);
+    } while (current !== last)
+}
 
 // returns whether or not npm install should be executed
 const watchFile = function () {
 
-    let packagePath = __dirname + '/../../../package.json'
-    let packageHashPath = __dirname + '/../../../packagehash.txt'
+    let packagePath = findPackageJson(); // __dirname + '/../../../package.json'
+    if (!packagePath) {
+        console.error("Can't find package.json travelling up from current working directory");
+    }
+    let packageHashPath = path.join(path.dirname(packagePath), "packagehash.txt"); // __dirname + '/../../../packagehash.txt'
     let recentDigest = hashFile(packagePath)
 
     // if the hash file doesn't exist or if it does and the hash

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "changed",
     "changes",
     "package"
-  ]
+  ],
+  "dependencies": {
+    "lodash.pick": "^4.4.0"
+  }
 }


### PR DESCRIPTION
use-case: updating `package.json` to, eg, add a script, causes `install-changed` to perform a re-install, where none is necessary. Similarly, tooling which puts configuration in `package.json` could trigger the same behavior (setting aside the discussion on whether putting tooling config in `package.json` is even a good idea (: )

also: search from cwd upward for package.json
      - allows for easier testing of this utility
        - can modify `package.json` and `node bin/install-changed.js` to test results
      - allows for usage anywhere, eg with npx:
        `npx install-changed`
      - guards against layout change of `node_modules`, or any fanciness
        which may be present on a machine using a local cache as a fallback

I've stuck with the style of the project -- single-quotes and no semi-colons -- though the last concerns me a little as one can introduce subtle bugs. Please let me know if you'd like me to also address this -- I can do so in a separate commit. I didn't want to do so if it would stand in the way of this PR.