### PR TITLE
Make npm install call synchronous

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var path = require('path')
 var crypto = require('crypto')
-var exec = require('child_process').exec
+var execSync = require('child_process').execSync
 var _pick = require("lodash.pick")
 
 // hashes a given file and returns the hex digest
@@ -46,16 +46,12 @@ const watchFile = function () {
 
         console.log('package.json modified. Installing...')
 
-        exec('npm install', function callback(error, stdout, stderr) {
-
-            if (!error) {
-                fs.writeFileSync(packageHashPath, recentDigest)     // write to hash to file for future use
-            }
-
-            console.log(stdout)
-            console.log(stderr)
-        })
-
+        try {
+            execSync('npm install');
+            fs.writeFileSync(packageHashPath, recentDigest)     // write to hash to file for future use
+        } catch (error){
+            console.log(error)
+        }
         return true
     }
     console.log('package.json not modified.')


### PR DESCRIPTION
Without this, if you count on install-changed in a script to finish before other require
statements, your js file may start loading other require statements before they are
available and npm install will fail to complete because an exception was thrown.