### PR TITLE
feat: support update only

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Usage: install-changed [options]
 Options:
   --install-command [command]  The command to run when dependencies need to be installed/updated
   --hash-filename [filename]   Filename where hash of dependencies will be written to
+  -u, --update-only            Only update the hash
   -h, --help                   display help for command
 ```
 
@@ -45,6 +46,8 @@ Example
 install-changed --hash-filename .packagehash --install-command "npm ci"
 ```
 This will use the file `.packagehash` to store a hash of the installed dependencies and run `npm ci` instead of `npm install` when packages need to be installed / updated.
+
+There may be some cases you just only want to update the hash. For example, when you are installing a new package you don't want the script to install the package again later. You can use the `---update-only` for that.
 
 **Programatically**
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usage: install-changed [options]
 Options:
   --install-command [command]  The command to run when dependencies need to be installed/updated
   --hash-filename [filename]   Filename where hash of dependencies will be written to
-  -u, --update-only            Only update the hash
+  -u, --hash-only            Only update the hash
   -h, --help                   display help for command
 ```
 
@@ -47,7 +47,7 @@ install-changed --hash-filename .packagehash --install-command "npm ci"
 ```
 This will use the file `.packagehash` to store a hash of the installed dependencies and run `npm ci` instead of `npm install` when packages need to be installed / updated.
 
-There may be some cases you just only want to update the hash. For example, when you are installing a new package you don't want the script to install the package again later. You can use the `---update-only` for that.
+There may be some cases you just only want to update the hash. For example, when you are installing a new package you don't want the script to install the package again later. You can use the `---hash-only` for that.
 
 **Programatically**
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usage: install-changed [options]
 Options:
   --install-command [command]  The command to run when dependencies need to be installed/updated
   --hash-filename [filename]   Filename where hash of dependencies will be written to
-  -u, --hash-only            Only update the hash
+  --hash-only                  Only update the hash
   -h, --help                   display help for command
 ```
 

--- a/bin/install-changed.js
+++ b/bin/install-changed.js
@@ -7,12 +7,12 @@ const watcher = require('../lib/main')
 program
   .option('--install-command [command]', 'The command to run when dependencies need to be installed/updated')
   .option('--hash-filename [filename]', 'Filename where hash of dependencies will be written to')
-  .option('-uo --update-only', 'Only update the hash')
+  .option('--hash-only', 'Only update the hash')
 
 program.parse(process.argv)
 
 watcher({
   installCommand: program.installCommand,
   hashFilename: program.hashFilename,
-  isUpdateOnly: program.updateOnly
+  isHashOnly: program.hashOnly
 })

--- a/bin/install-changed.js
+++ b/bin/install-changed.js
@@ -7,10 +7,12 @@ const watcher = require('../lib/main')
 program
   .option('--install-command [command]', 'The command to run when dependencies need to be installed/updated')
   .option('--hash-filename [filename]', 'Filename where hash of dependencies will be written to')
+  .option('-uo --update-only', 'Only update the hash')
 
 program.parse(process.argv)
 
 watcher({
   installCommand: program.installCommand,
-  hashFilename: program.hashFilename
+  hashFilename: program.hashFilename,
+  isUpdateOnly: program.updateOnly
 })

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,12 +49,14 @@ const watchFile = ({
   // if the hash file doesn't exist
   // or if it does and the hash is different
   if (!fs.existsSync(packageHashPath) || fs.readFileSync(packageHashPath, 'utf-8') !== recentDigest) {
+    console.log('package.json has been modified.')
+
     if (isHashOnly) {
-      console.log('')
+      console.log('Updating hash only because --hash-only is true.')
       return true
     }
 
-    console.log('package.json has been modified. But we only update the hash this time.')
+    console.log('Installing and updating hash.')
 
     try {
       execSync(

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,11 +49,12 @@ const watchFile = ({
   // if the hash file doesn't exist
   // or if it does and the hash is different
   if (!fs.existsSync(packageHashPath) || fs.readFileSync(packageHashPath, 'utf-8') !== recentDigest) {
-    console.log(`package.json has been modified.${isHashOnly ? '' : 'Installing...'}`)
-
     if (isHashOnly) {
+      console.log('')
       return true
     }
+
+    console.log('package.json has been modified. But we only update the hash this time.')
 
     try {
       execSync(

--- a/lib/main.js
+++ b/lib/main.js
@@ -35,7 +35,7 @@ const findPackageJson = () => {
 const watchFile = ({
   hashFilename = 'packagehash.txt',
   installCommand = 'npm install',
-  isUpdateOnly = false
+  isHashOnly = false
 }) => {
   const packagePath = findPackageJson()
 
@@ -49,9 +49,9 @@ const watchFile = ({
   // if the hash file doesn't exist
   // or if it does and the hash is different
   if (!fs.existsSync(packageHashPath) || fs.readFileSync(packageHashPath, 'utf-8') !== recentDigest) {
-    console.log(`package.json has been modified.${isUpdateOnly ? '' : 'Installing...'}`)
+    console.log(`package.json has been modified.${isHashOnly ? '' : 'Installing...'}`)
 
-    if (isUpdateOnly) {
+    if (isHashOnly) {
       return true
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,7 +34,8 @@ const findPackageJson = () => {
 // returns whether or not npm install should be executed
 const watchFile = ({
   hashFilename = 'packagehash.txt',
-  installCommand = 'npm install'
+  installCommand = 'npm install',
+  isUpdateOnly = false
 }) => {
   const packagePath = findPackageJson()
 
@@ -48,7 +49,11 @@ const watchFile = ({
   // if the hash file doesn't exist
   // or if it does and the hash is different
   if (!fs.existsSync(packageHashPath) || fs.readFileSync(packageHashPath, 'utf-8') !== recentDigest) {
-    console.log('package.json has been modified. Installing...')
+    console.log(`package.json has been modified.${isUpdateOnly ? '' : 'Installing...'}`)
+
+    if (isUpdateOnly) {
+      return true
+    }
 
     try {
       execSync(


### PR DESCRIPTION
There may be some cases you just only want to update the hash. For example, when you are installing a new package you don't want the script to install the package again later. You can use the `---update-only` for that.

@ninesalt In case you miss this.