### PR TITLE
fix not writing hash when hash only option is specified.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -53,6 +53,11 @@ const watchFile = ({
 
     if (isHashOnly) {
       console.log('Updating hash only because --hash-only is true.')
+      try {
+        fs.writeFileSync(packageHashPath, recentDigest) // write to hash to file for future use
+      } catch (error) {
+        console.log(error)
+      }
       return true
     }
 


### PR DESCRIPTION
It seems like we exited before actually updating any hash files with the recent hash-only option.

The following PR fixes that.