### PR TITLE
Use package-changed

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,35 +1,5 @@
-const fs = require('fs')
-const path = require('path')
-const crypto = require('crypto')
 const execSync = require('child_process').execSync
-
-// hashes a given file and returns the hex digest
-const hashFile = (filepath) => {
-  const hashSum = crypto.createHash('md5')
-  const contents = fs.readFileSync(filepath, 'utf-8')
-  const packageBlob = JSON.parse(contents)
-
-  const dependencies = {
-    dependencies: packageBlob['dependencies'] || {},
-    devDependencies: packageBlob['devDependencies'] || {}
-  }
-  const depsJson = JSON.stringify(dependencies)
-  hashSum.update(Buffer.from(depsJson))
-  return hashSum.digest('hex')
-}
-
-const findPackageJson = () => {
-  let current = process.cwd()
-  let last = current
-  do {
-    const search = path.join(current, 'package.json')
-    if (fs.existsSync(search)) {
-      return search
-    }
-    last = current
-    current = path.dirname(current)
-  } while (current !== last)
-}
+const { isPackageChanged } = require('package-changed')
 
 // returns whether or not npm install should be executed
 const watchFile = ({
@@ -37,22 +7,20 @@ const watchFile = ({
   installCommand = 'npm install',
   isHashOnly = false
 }) => {
-  const packagePath = findPackageJson()
+  // if the hash file doesn't exist or if it does and the hash is different
+  const {
+    hash,
+    writeHash
+  } = isPackageChanged({
+    hashFilename
+  })
 
-  if (!packagePath) {
-    console.error('Cannot find package.json. Travelling up from current working directory')
-  }
-
-  const packageHashPath = path.join(path.dirname(packagePath), hashFilename)
-  const recentDigest = hashFile(packagePath)
-
-  // if the hash file doesn't exist
-  // or if it does and the hash is different
-  if (!fs.existsSync(packageHashPath) || fs.readFileSync(packageHashPath, 'utf-8') !== recentDigest) {
+  if (hash) {
     console.log('package.json has been modified.')
 
     if (isHashOnly) {
       console.log('Updating hash only because --hash-only is true.')
+      writeHash()
       return true
     }
 
@@ -65,7 +33,7 @@ const watchFile = ({
           stdio: 'inherit'
         }
       )
-      fs.writeFileSync(packageHashPath, recentDigest) // write to hash to file for future use
+      writeHash() // write to hash to file for future use
     }
     catch (error) {
       console.log(error)

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,13 +9,13 @@ const watchFile = ({
 }) => {
   // if the hash file doesn't exist or if it does and the hash is different
   const {
-    hash,
+    isChanged,
     writeHash
   } = isPackageChanged({
     hashFilename
   })
 
-  if (hash) {
+  if (isChanged) {
     console.log('package.json has been modified.')
 
     if (isHashOnly) {
@@ -33,7 +33,7 @@ const watchFile = ({
           stdio: 'inherit'
         }
       )
-      writeHash() // write to hash to file for future use
+      writeHash() // write hash to file for future use
     }
     catch (error) {
       console.log(error)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1077,6 +1077,11 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
+    "package-changed": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/package-changed/-/package-changed-1.0.2.tgz",
+      "integrity": "sha512-N60I/Y5Y6HeBA+Yzjh98PeyfUoeJEi7UJY+rBHDEOpSduT6EmhzUYcCoIF8rd2LczkGW2uCGuCWOZmv7SBZl2A=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1078,9 +1078,9 @@
       "dev": true
     },
     "package-changed": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/package-changed/-/package-changed-1.0.2.tgz",
-      "integrity": "sha512-N60I/Y5Y6HeBA+Yzjh98PeyfUoeJEi7UJY+rBHDEOpSduT6EmhzUYcCoIF8rd2LczkGW2uCGuCWOZmv7SBZl2A=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/package-changed/-/package-changed-1.2.1.tgz",
+      "integrity": "sha512-puhAKcgQZfIX6fBHnD52miUxZqd7D+6IbPH30u2w1Q4eqtrJq4DrHHGV8lpM9cJanlEyPmgWNbV14KjjUcr1Gw=="
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "dependencies": {
     "commander": "^5.1.0",
-    "package-changed": "^1.0.2"
+    "package-changed": "^1.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-standard": "^4.0.0"
   },
   "dependencies": {
-    "commander": "^5.1.0"
+    "commander": "^5.1.0",
+    "package-changed": "^1.0.2"
   }
 }


### PR DESCRIPTION
For one of my upcoming projects I needed to simply know if the package was changed or not. 
My use case was not related to installing packages so I exctracted the code for that to `package-changed` which I'll be using in my project.

Since `package-changed` contains the core (converted to typescript though) of `install-changed` I submit this PR in case you would be interested in using it as a dependency so you could reduce maintenance work on `install-changed`. I noticed it has been one year since its last release on npm and merged pull requests dont get released so I understand you probably have other things on your mind than maintaining and releasing new versions for this package.

If you have thoughts, please let me know.